### PR TITLE
Add order.info params to oanda's clientExtensions

### DIFF
--- a/btoandav20/stores/oandav20store.py
+++ b/btoandav20/stores/oandav20store.py
@@ -514,7 +514,8 @@ class OandaV20Store(with_metaclass(MetaSingleton, object)):
                         trailamount,
                         '.%df' % order.data.contractdetails['displayPrecision']),
                     clientExtensions=v20.transaction.ClientExtensions(
-                        id=self._oref_to_client_id(stopside.ref)
+                        id=self._oref_to_client_id(stopside.ref),
+                        comment=json.dumps(order.info)
                     ).dict()
                 ).dict()
             else:
@@ -523,7 +524,8 @@ class OandaV20Store(with_metaclass(MetaSingleton, object)):
                         stopside.price,
                         '.%df' % order.data.contractdetails['displayPrecision']),
                     clientExtensions=v20.transaction.ClientExtensions(
-                        id=self._oref_to_client_id(stopside.ref)
+                        id=self._oref_to_client_id(stopside.ref),
+                        comment=json.dumps(order.info)
                     ).dict()
                 ).dict()
 
@@ -533,13 +535,15 @@ class OandaV20Store(with_metaclass(MetaSingleton, object)):
                     takeside.price,
                     '.%df' % order.data.contractdetails['displayPrecision']),
                 clientExtensions=v20.transaction.ClientExtensions(
-                    id=self._oref_to_client_id(takeside.ref)
+                    id=self._oref_to_client_id(takeside.ref),
+                    comment=json.dumps(order.info)
                 ).dict()
             ).dict()
 
         # store backtrader order ref in client extensions
         okwargs['clientExtensions'] = v20.transaction.ClientExtensions(
-            id=self._oref_to_client_id(order.ref)
+            id=self._oref_to_client_id(order.ref),
+            comment=json.dumps(order.info)
         ).dict()
 
         okwargs.update(**kwargs)  # anything from the user

--- a/btoandav20/stores/oandav20store.py
+++ b/btoandav20/stores/oandav20store.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import collections
 import threading
 import copy
+import json
 import time as _time
 from datetime import datetime, timezone
 


### PR DESCRIPTION
This change adds the parameters from order.info to oanda's clientExtensions (v20.transaction.ClientExtensions) as comment.
Therefore it's possible to access those parameters earlier in the "Backtrader Strategy". Specifically within notify_store() instead of notify_order().